### PR TITLE
refactor(ci): simplify docker build workflow and remove unused Docker args

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,96 +1,56 @@
 name: Build Docker Image
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to build from'
-        required: true
-        type: string
-        default: 'main'
-      push_image:
-        description: 'Push image to registry'
-        required: false
-        type: boolean
-        default: false
-      image_tag:
-        description: 'Custom image tag (defaults to branch name)'
-        required: false
-        type: string
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
-      - 'infra/**'
-      - 'package.json'
-      - 'yarn.lock'
-      - 'tsconfig.json'
-      - '.github/workflows/docker-build.yml'
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  workflow_dispatch:
 
 jobs:
   build:
-    name: Build Docker Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Container Registry
-        if: ${{ github.event.inputs.push_image == true || github.event_name == 'push' }}
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-,format=long
-            type=raw,value=${{ github.event.inputs.image_tag || github.ref_name }},enable={{is_default_branch}}
-            type=raw,value=${{ github.event.inputs.image_tag || github.ref_name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+      - name: Add SHORT_SHA
+        run: echo "SHORT_SHA=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (main)
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./infra/Dockerfile
-          push: ${{ github.event.inputs.push_image == true || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ github.event.inputs.image_tag || github.ref_name }}
-            BUILD_DATE=${{ github.event.repository.updated_at }}
-            GIT_REF=${{ github.ref }}
-            GIT_SHA=${{ github.sha }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/operator-reward-distributor:latest
+            ghcr.io/${{ github.repository_owner }}/operator-reward-distributor:${{ env.SHORT_SHA }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Output image info
-        run: |
-          echo "Image tags:"
-          echo "${{ steps.meta.outputs.tags }}"
-          echo ""
-          echo "To pull this image:"
-          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.image_tag || github.ref_name }}"
+      - name: Build and push Docker image (other branches)
+        if: ${{ github.ref != 'refs/heads/main' }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./infra/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/operator-reward-distributor:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/operator-reward-distributor:${{ env.SHORT_SHA }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,7 +1,7 @@
 # --- Application configuration ---
 
 # WebSocket endpoint(s) for chain RPC (comma-separated supported)
-CHAIN_WS=ws://node:9944,wss://auto-evm.mainnet.autonomys.xyz/ws
+CHAIN_WS=ws://node:8944,wss://auto-evm.mainnet.autonomys.xyz/ws
 
 # Free-form label for logs/telemetry
 CHAIN_ID=autonomys-mainnet
@@ -33,9 +33,9 @@ ACCOUNT_PRIVATE_KEY=<0xYOUR_PRIVATE_KEY_HERE>
 DB_URL=sqlite:/data/ord.sqlite
 
 # --- Docker image configuration ---
-# Set APP_IMAGE to use a pre-built image from registry (e.g., ghcr.io/autonomys/operator-reward-distributor:main)
+# Set APP_IMAGE to use a pre-built image from registry (e.g., ghcr.io/subspace/operator-reward-distributor:latest)
 # Leave unset to build locally from source
-# APP_IMAGE=ghcr.io/autonomys/operator-reward-distributor:main
+# APP_IMAGE=ghcr.io/subspace/operator-reward-distributor:latest
 
 # --- Node container ---
 # Update these values to match your chosen node image and network
@@ -43,5 +43,5 @@ NODE_DOCKER_TAG=mainnet-2025-aug-20
 NETWORK_ID=mainnet
 DOMAIN_ID=0
 # Host directory bound to /data (contains ord.sqlite and logs/)
-HOST_DATA_DIR=../../data
+HOST_DATA_DIR=../data
 

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,11 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-# Build arguments for metadata
-ARG VERSION=latest
-ARG BUILD_DATE
-ARG GIT_REF
-ARG GIT_SHA
-
 FROM node:20-alpine AS builder
 WORKDIR /app
 
@@ -29,19 +23,6 @@ RUN yarn build
 
 FROM node:20-alpine AS runner
 WORKDIR /app
-
-# Build metadata labels
-ARG VERSION=latest
-ARG BUILD_DATE
-ARG GIT_REF
-ARG GIT_SHA
-
-LABEL org.opencontainers.image.title="operator-reward-distributor" \
-      org.opencontainers.image.description="Operator Reward Distributor for Autonomys Network" \
-      org.opencontainers.image.version="${VERSION}" \
-      org.opencontainers.image.created="${BUILD_DATE}" \
-      org.opencontainers.image.revision="${GIT_SHA}" \
-      org.opencontainers.image.source="https://github.com/autonomys/operator-reward-distributor"
 
 ENV NODE_ENV=production
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,9 +4,13 @@ This directory contains deployment artifacts and instructions for running Operat
 
 ### Structure
 
-- `compose/` — Docker Compose deployment (local node, scheduler, API)
+- `Dockerfile` — app image build (TypeScript → `dist/`)
+- `docker-compose.yml` — Docker Compose stack (scheduler + API + Nginx proxy; optional local node)
+- `docker-compose.local-node.yml` — local-node override (makes `scheduler` wait for `node` health)
+- `nginx.conf` — Nginx config template (used by `proxy`)
+- `.env.example` — example environment for Docker Compose
 
-The runnable artifacts live under `infra/compose/`.
+The runnable artifacts live directly under `infra/`.
 
 ### Prerequisites
 
@@ -14,34 +18,30 @@ The runnable artifacts live under `infra/compose/`.
 
 ### Building Docker Images with GitHub Actions
 
-The repository includes a GitHub Actions workflow (`.github/workflows/docker-build.yml`) that can build Docker images from any branch.
+The repository includes a GitHub Actions workflow (`.github/workflows/docker-build.yml`) that builds Docker images on pushes to `main` and via manual dispatch.
 
 #### Using GitHub Actions UI
 
 1. Go to the **Actions** tab in your GitHub repository
 2. Select **Build Docker Image** workflow
-3. Click **Run workflow**
-4. Choose the branch to build from
-5. Optionally:
-   - Enable **Push image to registry** to push to GitHub Container Registry
-   - Set a custom **Image tag** (defaults to branch name)
-6. Click **Run workflow**
+3. Select the branch to build from using the branch dropdown (defaults to `main`)
+4. Click **Run workflow**
 
 #### Using Pre-built Images
 
 After building an image via GitHub Actions, you can use it in your deployment:
 
-1. Set `APP_IMAGE` in `infra/compose/.env`:
+1. Set `APP_IMAGE` in `infra/.env`:
 
 ```bash
-APP_IMAGE=ghcr.io/autonomys/operator-reward-distributor:main
+APP_IMAGE=ghcr.io/subspace/operator-reward-distributor:latest
 ```
 
 2. Pull and start the stack (no build needed):
 
 ```bash
-docker compose -f infra/compose/docker-compose.yml pull
-docker compose -f infra/compose/docker-compose.yml up -d
+docker compose -f infra/docker-compose.yml pull
+docker compose -f infra/docker-compose.yml up -d
 ```
 
 **Note:** When `APP_IMAGE` is set, docker-compose will use the pre-built image and skip local builds. Leave `APP_IMAGE` unset to build from source locally.
@@ -50,71 +50,69 @@ docker compose -f infra/compose/docker-compose.yml up -d
 
 Images are tagged with:
 
-- Branch name (e.g., `main`, `develop`)
-- Commit SHA with branch prefix (e.g., `main-abc1234`)
-- Custom tag if specified in workflow dispatch
+- `latest` and short commit SHA (main branch only)
+- Branch name and short commit SHA (other branches)
 
-Images are pushed to: `ghcr.io/autonomys/operator-reward-distributor`
+Images are pushed to: `ghcr.io/subspace/operator-reward-distributor`
 
 ### Quick start (Docker Compose)
 
 1. Copy and edit environment:
 
 ```bash
-cp infra/compose/.env.example infra/compose/.env
+cp infra/.env.example infra/.env
 ```
 
 2. Build and start the stack:
 
 ```bash
-docker compose -f infra/compose/docker-compose.yml up -d --build
+docker compose -f infra/docker-compose.yml up -d --build
 ```
 
-3. Check API health:
+3. Check API health (via the Nginx proxy):
 
 ```bash
-curl -s http://127.0.0.1:${SERVER_PORT:-3001}/health
+curl -s http://127.0.0.1:${PROXY_HOST_PORT:-80}/health
 ```
 
 4. Tail logs:
 
 ```bash
-docker compose -f infra/compose/docker-compose.yml logs -f ord-api ord-scheduler
+docker compose -f infra/docker-compose.yml logs -f api scheduler
 ```
 
 ### Configuration
 
-- App variables are documented in `src/config.ts`. Compose reads `infra/compose/.env` via `env_file`.
+- App variables are documented in `src/config.ts`. Compose reads `infra/.env` via `env_file`.
 - Root `.env.example` is for local development (`yarn dev`/`yarn serve`) and is not used by Compose.
-- Set `APP_IMAGE` in `infra/compose/.env` to use a pre-built image from registry (e.g., from GitHub Actions). Leave unset to build locally.
-- Set `NODE_DOCKER_TAG`, `NETWORK_ID`, and (optionally) `DOMAIN_ID` in `infra/compose/.env`. Compose uses `${DOMAIN_ID:-0}` to default the domain id to 0 if unset. Adjust node flags in `infra/compose/docker-compose.yml` as needed.
+- Set `APP_IMAGE` in `infra/.env` to use a pre-built image from registry (e.g., from GitHub Actions). Leave unset to build locally.
+- Set `NODE_DOCKER_TAG`, `NETWORK_ID`, and (optionally) `DOMAIN_ID` in `infra/.env`. Compose uses `${DOMAIN_ID:-0}` to default the domain id to 0 if unset. Adjust node flags in `infra/docker-compose.yml` as needed.
 - Conditional local node: the `node` service is under the `local-node` profile. To run with a local node, use the local-node override (adds `scheduler -> node` health dependency) and pass the profile:
 
-````bash
+```bash
 docker compose \
-  -f infra/compose/docker-compose.yml \
-  -f infra/compose/docker-compose.local-node.yml \
+  -f infra/docker-compose.yml \
+  -f infra/docker-compose.local-node.yml \
   --profile local-node up -d --build
+```
 
 Alternatively, set the files once in your shell:
 
 ```bash
-export COMPOSE_FILE=infra/compose/docker-compose.yml:infra/compose/docker-compose.local-node.yml
+export COMPOSE_FILE=infra/docker-compose.yml:infra/docker-compose.local-node.yml
 docker compose --profile local-node up -d --build
-````
-
-````
+```
 
 ### Upgrades
 
 ```bash
-docker compose -f infra/compose/docker-compose.yml up -d --build
-````
+docker compose -f infra/docker-compose.yml up -d --build
+```
 
 ### Shutdown
 
 ```bash
-docker compose -f infra/compose/docker-compose.yml down
+docker compose -f infra/docker-compose.yml down
 ```
 
 ### Run with built-in Nginx proxy (local)
@@ -122,14 +120,14 @@ docker compose -f infra/compose/docker-compose.yml down
 1. Copy env and adjust values
 
 ```bash
-cp infra/compose/.env.example infra/compose/.env
+cp infra/.env.example infra/.env
 # edit CHAIN_WS, ACCOUNT_PRIVATE_KEY, TIP_AI3, DAILY_CAP_AI3, etc.
 ```
 
 2. Start stack (scheduler + api + proxy)
 
 ```bash
-docker compose -f infra/compose/docker-compose.yml up -d --build
+docker compose -f infra/docker-compose.yml up -d --build
 ```
 
 3. Verify
@@ -142,7 +140,7 @@ Notes:
 
 - API service binds to `SERVER_HOST=0.0.0.0` inside the network; it is not exposed directly.
 - Nginx listens on host port `${PROXY_HOST_PORT}` (default 80) and proxies to `api:${SERVER_PORT}`.
-- Sensitive endpoints `/config` and `/info` are allowlisted to `127.0.0.1` by default in `infra/compose/nginx.conf`.
+- Sensitive endpoints `/config` and `/info` are allowlisted to `127.0.0.1` by default in `infra/nginx.conf`.
 - For production, front Nginx with TLS (LB or certbot) and restrict access as needed.
 
 ### Run with local-node profile (embedded node)
@@ -150,7 +148,7 @@ Notes:
 1. Copy env and adjust values
 
 ```bash
-cp infra/compose/.env.example infra/compose/.env
+cp infra/.env.example infra/.env
 # edit NODE_DOCKER_TAG, NETWORK_ID (and optionally DOMAIN_ID)
 # set ACCOUNT_PRIVATE_KEY, TIP_AI3, DAILY_CAP_AI3, etc.
 ```
@@ -159,8 +157,8 @@ cp infra/compose/.env.example infra/compose/.env
 
 ```bash
 docker compose \
-  -f infra/compose/docker-compose.yml \
-  -f infra/compose/docker-compose.local-node.yml \
+  -f infra/docker-compose.yml \
+  -f infra/docker-compose.local-node.yml \
   --profile local-node up -d --build
 ```
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,5 +1,5 @@
 x-app-build: &app-build
-  context: ../..
+  context: ..
   dockerfile: infra/Dockerfile
 
 name: ord


### PR DESCRIPTION
This pull request refactors and simplifies the Docker deployment workflow and documentation for the project, with a focus on standardizing image naming and tags, cleaning up the Docker build process, and making environment and compose file usage more consistent. It also updates references from "autonomys" to "subspace" to reflect a change in image naming. The most important changes are grouped below.

**GitHub Actions and Docker Build Workflow:**

* Simplified the `.github/workflows/docker-build.yml` workflow to trigger on pushes to `main` and manual dispatch, removed complex metadata extraction, and standardized image tags to use branch name and short commit SHA. Updated image naming to `ghcr.io/${{ github.repository_owner }}/operator-reward-distributor`. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R4-L37) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L52-L96)

**Dockerfile and Build Metadata:**

* Removed unused build arguments and metadata labels from `infra/Dockerfile` for a cleaner image build process. [[1]](diffhunk://#diff-b9cd78c496c6fb74c62087ae0542572f83c95cb468f73ebf237702df61fe4a88L3-L8) [[2]](diffhunk://#diff-b9cd78c496c6fb74c62087ae0542572f83c95cb468f73ebf237702df61fe4a88L33-L45)

**Environment and Compose Configuration:**

* Updated `infra/.env.example` to use the new image naming convention (`ghcr.io/subspace/operator-reward-distributor`), changed the default chain RPC port, and adjusted the data directory path for consistency. [[1]](diffhunk://#diff-c00065fcc7bc71f589649fea5ef8a7dc5ab12574bf0557ab774a21de9d029ff2L4-R4) [[2]](diffhunk://#diff-c00065fcc7bc71f589649fea5ef8a7dc5ab12574bf0557ab774a21de9d029ff2L36-R46)
* Updated `infra/docker-compose.yml` to use the correct build context path.

**Documentation Improvements:**

* Refactored `infra/README.md` to document the new workflow, image tags, and usage of `.env` and compose files directly under `infra/` instead of nested `compose/` directories. Updated all references to the new image name and clarified instructions for running, upgrading, and configuring the stack. [[1]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4L7-R46) [[2]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4L53-R103) [[3]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4L111-R133) [[4]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4L145-R154) [[5]](diffhunk://#diff-a7185b3c971728dd36f544a064be689d9d77aef5a91e271608c5d0324c3710c4L162-R164)

These changes streamline the deployment process, reduce maintenance overhead, and improve clarity for users deploying or contributing to the project.…file build args

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines Docker build/publish workflow, updates image/tag conventions and env defaults, and aligns docs/compose paths under infra/.
> 
> - **CI / Docker Build**:
>   - Trigger on `push` to `main` and manual dispatch; optional `push_image` (default true).
>   - Replace registry login + metadata steps with simple login and env vars `SHORT_SHA`/`BRANCH_NAME`.
>   - Standardize tags to `ghcr.io/${{ github.repository_owner }}/operator-reward-distributor` with branch and short SHA; simplified `push` condition.
> - **Dockerfile**:
>   - Remove unused build args and OCI labels for a leaner build.
> - **Config / Compose**:
>   - `infra/.env.example`: change `CHAIN_WS` WS port to `8944`, switch image name to `ghcr.io/subspace/operator-reward-distributor`, adjust `HOST_DATA_DIR`.
>   - `infra/docker-compose.yml`: fix build `context` path to `..`.
> - **Docs** (`infra/README.md`):
>   - Reflect new workflow, tag scheme (branch + short SHA), image repo `ghcr.io/subspace/operator-reward-distributor`, and direct use of files under `infra/` (no `compose/` subdir).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d75ecff9c4395a2230bd1c80ae6135c737cc5295. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->